### PR TITLE
Fix Mercado Pago token property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ aws.secret-key=${AWS_SECRET_ACCESS_KEY}
 gemini.api.key=${gemini.api.key}
 
 
-mercadopago.access-token={mercadopago.access-token}
+mercadopago.access-token=${mercadopago.access-token}
 
 
 spring.mail.host=smtp.gmail.com


### PR DESCRIPTION
## Summary
- ensure Mercadopago access token uses property placeholder

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68897d1e9a54832da531f8f8efd01ab6